### PR TITLE
Experimental support for recursive calls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ mod __ {
         ops::{
             FnMut, FnOnce,
         },
-        option::Option::{Some as Some_},
+        option::Option::{Some as Some_, None as None_},
         result::Result::{Ok as Ok_, Err as Err_},
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,11 @@ mod __ {
     pub
     use ::core::{
         convert::Into,
-        option::Option,
-        result::Result,
+        ops::{
+            FnMut, FnOnce,
+        },
+        option::Option::{Some as Some_},
+        result::Result::{Ok as Ok_, Err as Err_},
     };
 
     pub
@@ -82,7 +85,8 @@ mod __ {
         }
     }
 
-    pub struct NoneError;
+    mod hidden { pub struct NoneError; }
+    use hidden::NoneError;
 
     impl<T> Try for Option<T> {
         type Ok = T;

--- a/src/proc_macros/mod.rs
+++ b/src/proc_macros/mod.rs
@@ -15,9 +15,9 @@ use ::quote::{
 };
 use ::syn::{*,
     parse::{
-        Nothing,
+        // Nothing,
         Parse,
-        // Parser,
+        Parser,
         ParseStream,
     },
     // punctuated::Punctuated,
@@ -54,6 +54,7 @@ type Str = ::std::borrow::Cow<'static, str>;
 struct Attrs {
     lifetime: Str,
     continuation: Option<Ident>,
+    recursive: bool,
 }
 
 /// See [the main documentation of the crate for info about this attribute](

--- a/src/proc_macros/mod.rs
+++ b/src/proc_macros/mod.rs
@@ -70,8 +70,8 @@ fn with (
         parse_macro_input!(input as Input),
     );
 
-    handle_returning_locals(&mut *fun, attrs);
-    if let Err(err) = handle_let_bindings::f(&mut *fun, attrs) {
+    let ty = handle_returning_locals(&mut *fun, attrs);
+    if let Err(err) = handle_let_bindings::f(&mut *fun, attrs, ty) {
         return err.to_compile_error().into();
     }
 

--- a/src/proc_macros/wrap_statements_inside_closure_body.rs
+++ b/src/proc_macros/wrap_statements_inside_closure_body.rs
@@ -86,7 +86,7 @@ fn wrap_statements_inside_closure_body (
                     use $krate::{
                         ControlFlow,
                         Into,
-                        Result,
+                        Ok_, Err_,
                         Try,
                     };
                 }
@@ -167,8 +167,8 @@ fn wrap_statements_inside_closure_body (
                         self.visit_expr_mut(matchee);
                         *expr = parse_quote! {
                             match #matchee { it => match #Try::into_result(it) {
-                                | #Result::Ok(it) => it,
-                                | #Result::Err(err) => {
+                                | #Ok_(it) => it,
+                                | #Err_(err) => {
                                     return #ControlFlow::EarlyReturn(
                                         #Try::from_err(
                                             #Into::into(err)

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -219,3 +219,20 @@ fn loops ()
     ```
     */
 }
+
+#[test]
+#[with]
+fn recursive ()
+{
+    /// Recursive
+    #[with(recursive = true)]
+    fn recursive (recurse: bool) -> &'ref ()
+    {
+        if recurse {
+            let _: &'ref _ = recursive(false);
+        }
+        &()
+    }
+    #[with(recursive)]
+    let _it: &'ref () = recursive(true);
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -233,6 +233,6 @@ fn recursive ()
         }
         &()
     }
-    #[with(recursive)]
+    #[with(recursive = true)]
     let _it: &'ref () = recursive(true);
 }

--- a/tests/ui/pass/attrs.rs
+++ b/tests/ui/pass/attrs.rs
@@ -64,6 +64,16 @@ fn foo ()
     with(&())
 }
 
+/// Recursive
+#[with(recursive = true)]
+fn rec (recurse: bool) -> &'ref ()
+{
+    if recurse {
+        let _: &'ref _ = rec(false);
+    }
+    &()
+}
+
 /// Trailing commas
 const _: () = {
     const _: () = {
@@ -74,6 +84,48 @@ const _: () = {
     const _: () = {
         #[with(
             'some_name , continuation_name = whatever ,
+        )]
+        fn __ ()
+        {}
+    };
+    const _: () = {
+        #[with(
+            'some_name , recursive = true ,
+        )]
+        fn __ ()
+        {}
+    };
+    const _: () = {
+        #[with(
+            'some_name , continuation_name = whatever , recursive = false ,
+        )]
+        fn __ ()
+        {}
+    };
+    const _: () = {
+        #[with(
+            'some_name , recursive = false , continuation_name = whatever ,
+        )]
+        fn __ ()
+        {}
+    };
+    const _: () = {
+        #[with(
+            'some_name , continuation_name = whatever , recursive = false
+        )]
+        fn __ ()
+        {}
+    };
+    const _: () = {
+        #[with(
+            recursive = false , continuation_name = whatever
+        )]
+        fn __ ()
+        {}
+    };
+    const _: () = {
+        #[with(
+            continuation_name = whatever, recursive = false
         )]
         fn __ ()
         {}


### PR DESCRIPTION
This PR implements an experimental work-around for https://github.com/rust-lang/rust/issues/77664:

A CPS-function can now express its intention to recurse using the `#[with(recursive = true)]` attribute, at which point the callback will be downgraded from `impl FnOnce(<fake ret value>) -> R` down to `&'_ mut (dyn '_ + FnMut(<rake ret value>))` (otherwise https://github.com/rust-lang/rust/issues/77664 leads to a "recursive type" compilation error _when instanciating / calling the function).

This means that callers will also need to adapt to this, which is is possible by using:

```rust
#[with(recursive = true)]
let binding: ... 'special ... = foo(...);
/* next statements evaluating to R */
```

This will lead a more convoluted unsugaring in order to convert the initial `FnOnce() -> R`:

```rust
// #[with(recursive = false)]
with_foo(..., |binding: ... '_ ...| {
    /* next statements evaluating to R */
});
```

into the required `&mut dyn FnMut(...)`:

```rust
// #[with(recursive = true)]
{
    let mut ret_slot = None; // : R
    let () = with_foo(..., &mut {
        //                                    required for a callback having the
        //                                    v  necessary higher-order lifetime
        let mut closure = Some(|binding: ... '_ ...| {
            /* next statements evaluating to R */
        });
        let ret_slot = &mut ret_slot;
        move |arg: ... '_ ...| -> () {
            ret_slot = Some(closure.take().unwrap()(arg));
        }
    });
    ret_slot.unwrap()
}
```

  - Note: you may notice that on top of the `#[with]` attribute, we still need to mention the special lifetime. Indeed, otherwise, Rust type inference is not good enough to infer that the intermediate closure needs a higher-order lifetime, and will fail with "closure is not general enough".

### Ergonomics

The ergonomics of all this are not good, hence my qualifying this functionality as "experimental".

One way to smooth them a bit (but until proper motivation is found, I won't be doing this with my crate (forwarding arguments with a proc-macro is quite cumbersome given that patterns cannot be forwarded as they are, _c.f._, the `binding` _vs._ `arg` distinction in the previous snippet)), is to use `recursive = true` on an inner helper function,

  - <details><summary>similarly to fibonacci: </summary>

    ```rust
    fn fibo (n: u64) -> u64
    {
        fn fibo_recursive (n: u64) -> (u64, u64)
        {
            if n <= 1 { (n, 0) } else {
                let (f_n_1, f_n_2) = fibo_recursive(n - 1);
                (f_n_1 + f_n_2, f_n_1)
           }
        }
        fibo_recursive(n).0
    }
    ```

    ___

    </details>

```rust
#[with]
fn foo (recurse: bool) -> &'ref ()
{
    #[with(recursive = true)]
    fn foo_rec (recurse: bool) -> &'ref ()
    {
        if recurse {
            let it: &'ref () = foo_rec(false);
            it
        } else {
            &()
        }
    }

    #[with(recursive = true)]
    let it: &'ref () = foo_rec(recurse);
    it
}
```

It's a bit cumbersome, but hopefully the recursive cases should not show up that often (there usually is a main recursive core function, and then wrappers around it, or it may call helper non-recursive `#[with]` functions). And as I said, implementing this wrapping automagically, albeit possible, does not seem critical.

