### PR TITLE
Support lifetime elision.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ keywords = [
     "cps",
 ]
 categories = [
+    "no-std",
     "rust-patterns",
 ]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
-#![forbid(unsafe_code)]
-
 #![cfg_attr(feature = "nightly",
     feature(external_doc),
     doc(include = "../README.md"),
 )]
+
+#![forbid(unsafe_code)]
+#![no_std]
+
 
 /// To avoid a bug when cross compiling
 extern crate proc_macros;

--- a/src/proc_macros/Cargo.toml
+++ b/src/proc_macros/Cargo.toml
@@ -33,7 +33,7 @@ proc-macro2 = "=1.0.*"
 quote = "=1.0.*"
 
 bat = { optional = true, version = "0.15.4" }
-func_wrap = "0.1.2"
+func_wrap = "0.1.3"
 
 [dependencies.syn]
 version = ">=1.0.1" # Only tested starting from 1.0.1 because of rustversion

--- a/src/proc_macros/mod.rs
+++ b/src/proc_macros/mod.rs
@@ -41,7 +41,7 @@ use self::{
 mod helpers;
 
 mod attrs;
-include!("handle_returning_locals.rs");
+mod handle_returning_locals;
 mod handle_let_bindings;
 mod wrap_statements_inside_closure_body;
 
@@ -115,7 +115,7 @@ fn handle_fn_like<Fun : FnLike> (
     outer_scope: Option<(&'_ Generics, ::func_wrap::ImplOrTrait<'_>)>
 ) -> Result<()>
 {
-    handle_returning_locals(fun, attrs, outer_scope)?;
+    handle_returning_locals::f(fun, attrs, outer_scope)?;
     if let Some(block) = fun.fields().block {
         handle_let_bindings::f(block, attrs)?;
     }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -253,3 +253,21 @@ fn object_safe ()
     let _: &'ref () = dyn_obj.foo();
     return;
 }
+
+#[with]
+fn _elision ()
+{
+    #[with]
+    fn check (_: &'_ ()) -> &'ref &'_ ()
+    {
+        &&()
+    }
+
+    match ::core::convert::identity(()) { ref it => {
+        let at_it = {
+            let &at_it: &'ref _ = check(it);
+            at_it
+        };
+        drop(at_it)
+    }};
+}


### PR DESCRIPTION
Fixes #7

This is achieved by having the (proc-)macro replace
elided lifetimes with auto-generated explicitly-named
equivalent signatures, before applying the rest of the
`with_locals` magic.

TODO:

  - [ ] Add UI tests to make sure the error messages are nice;

  - [ ] Add a functionality to hack `deny(elided_lifetimes_in_paths)`
    to make sure the macro does not misbehave (since it can't,
    otherwise, know there are elided lifetime parameters there).