### PR TITLE
Use `doc = include_str!` instead of `doc(include`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,6 +48,7 @@ jobs:
         rust-toolchains:
           - 1.42.0
           - stable
+          - nightly
     steps:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -59,14 +60,22 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@v2
 
-      - name: Cargo test (no UI)
+      - name: Cargo +nightly test (no UI)
+        if: matrix.rust-toolchains == 'nightly'
         uses: actions-rs/cargo@v1
         env:
-          RUSTC_BOOTSTRAP: "1"
           CI_SKIP_UI_TESTS: "1"
         with:
           command: test
           args: --features nightly
+
+      - name: Cargo test (no UI)
+        if: matrix.rust-toolchains != 'nightly'
+        uses: actions-rs/cargo@v1
+        env:
+          CI_SKIP_UI_TESTS: "1"
+        with:
+          command: test
 
   # == UI TESTS ==
   ui-test:

--- a/.github/workflows/future-proof.yml
+++ b/.github/workflows/future-proof.yml
@@ -35,11 +35,19 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@v2
 
-      - name: Cargo test (no UI)
+      - name: Cargo +nightly test (no UI)
+        if: matrix.rust-toolchains == 'nightly'
         uses: actions-rs/cargo@v1
         env:
-          RUSTC_BOOTSTRAP: "1"
           CI_SKIP_UI_TESTS: "1"
         with:
           command: test
           args: --features nightly
+
+      - name: Cargo test (no UI)
+        if: matrix.rust-toolchains != 'nightly'
+        uses: actions-rs/cargo@v1
+        env:
+          CI_SKIP_UI_TESTS: "1"
+        with:
+          command: test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
 #![forbid(unsafe_code)]
 
 #![cfg_attr(feature = "nightly",
-    feature(external_doc),
-    doc(include = "../README.md"),
+    cfg_attr(all(), doc = include_str!("../README.md")),
 )]
 
 /// To avoid a bug when cross compiling


### PR DESCRIPTION
This fixes CI breakage on `nightly` due to the latter having been removed.