### PR TITLE
Bump `bat` dependency (RUSTSEC-2021-0106) and commit to 0.3.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "with_locals"
-version = "0.3.0-rc1"  # Keep in sync with `proc_macros`
+version = "0.3.0"  # Keep in sync with `proc_macros`
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
@@ -29,7 +29,7 @@ categories = [
 [dependencies.proc_macros]
 path = "src/proc_macros"
 package = "with_locals-proc_macros"
-version = "0.3.0-rc1"
+version = "0.3.0"
 
 [features]
 nightly = []

--- a/src/proc_macros/Cargo.toml
+++ b/src/proc_macros/Cargo.toml
@@ -4,7 +4,7 @@ path = "mod.rs"
 
 [package]
 name = "with_locals-proc_macros"
-version = "0.3.0-rc1"  # Keep in sync with main `Cargo.toml`
+version = "0.3.0"  # Keep in sync with main `Cargo.toml`
 authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"]
 edition = "2018"
 
@@ -32,7 +32,7 @@ categories = [
 proc-macro2 = "=1.0.*"
 quote = "=1.0.*"
 
-bat = { optional = true, version = "0.15.4" }
+bat = { optional = true, version = "0.18.3" }
 func_wrap = "0.1.2"
 
 [dependencies.syn]


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2021-0106 (it was technically never reached, but ought to make dependents sleep better at night 🙃)